### PR TITLE
Add clap and tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "arrow"
 version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,7 +321,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -361,6 +416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
 name = "brotli"
 version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +489,53 @@ dependencies = [
  "wasm-bindgen",
  "winapi",
 ]
+
+[[package]]
+name = "clap"
+version = "4.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "const-random"
@@ -503,12 +611,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "flatbuffers"
 version = "23.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "rustc_version",
 ]
 
@@ -630,6 +759,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +772,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex_lit"
@@ -771,6 +912,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,6 +1029,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +1071,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +1109,16 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1027,7 +1204,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1045,6 +1222,12 @@ checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1196,7 +1379,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1207,8 +1390,23 @@ checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1277,6 +1475,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc6396159432b5c8490d4e301d8c705f61860b8b6c863bf79942ce5401968f3"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1409,6 +1620,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1681,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +1695,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1585,7 +1821,19 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1595,6 +1843,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1650,6 +1928,18 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -1883,12 +2173,16 @@ dependencies = [
 name = "wtf"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow",
  "bitcoin",
  "bitcoincore-rest",
  "chrono",
+ "clap",
  "parquet",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.71"
 arrow = "42.0.0"
 bitcoin = "0.30.0"
 bitcoincore-rest = "2.0.0"
 chrono = "0.4.26"
+clap = { version = "4.3.10", features = ["derive"] }
 parquet = "42.0.0"
 tokio = { version = "1.28.2", features = ["macros", "full"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod record;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,161 +1,34 @@
-use arrow::{
-    array::{ArrayRef, Float64Array, StringArray, UInt64Array},
-    datatypes::{DataType, Field, Schema},
-    record_batch::RecordBatch,
-};
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use tracing::metadata::LevelFilter;
+use tracing_subscriber::EnvFilter;
+use wtf::record::Record;
 
-use bitcoin::{Denomination, Txid};
-use bitcoincore_rest::{responses::GetMempoolEntryResult, Error, Network, RestApi, RestClient};
-use chrono::Timelike;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Instant,
-};
+#[derive(Parser)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
 
-use parquet::{arrow::ArrowWriter, basic::Compression, file::properties::WriterProperties};
-
-type Mempool = HashMap<Txid, GetMempoolEntryResult>;
+#[derive(Subcommand)]
+enum Commands {
+    Record,
+}
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
-    let rest_client = RestClient::network_default(Network::Bitcoin);
+async fn main() -> Result<()> {
+    let filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+    tracing_subscriber::fmt().with_env_filter(filter).init();
 
-    let mut prev_height = 0u64;
-    let mut this_height;
-    let mut prev_mempool: Mempool = HashMap::new();
-    let mut this_mempool: Mempool;
-    let mut prev_timestamp = 0i64;
+    let cli = Cli::parse();
 
-    loop {
-        // execute once per quarter-minute (:00/:15/:30/:45), preventing double execution
-        let now = chrono::Utc::now();
-        if now.second() % 15 != 0 || prev_timestamp == now.timestamp() {
-            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-            continue;
-        }
-
-        // check height
-        this_height = rest_client.get_chain_info().await?.blocks;
-        let is_new_height = prev_height != this_height;
-        if is_new_height {
-            prev_mempool = HashMap::new();
-            println!("new_height: {:?}", this_height);
-        }
-
-        let start = Instant::now();
-        this_mempool = rest_client.get_mempool().await?;
-        let duration = start.elapsed();
-
-        let batch = create_batchrecord_delta_from_pools(&prev_mempool, &this_mempool);
-
-        println!(
-            "batch_num_rows: {:?}, load_mempool_duration_millis: {:?}",
-            batch.num_rows(),
-            duration.as_millis()
-        );
-
-        let mut filename = std::path::PathBuf::new();
-        let day = now.format("%Y/%m/%d").to_string();
-        let timestamp = now.timestamp();
-        let suffix = if is_new_height { "full" } else { "delta" };
-        filename.push("data");
-        filename.extend(day.split('/'));
-        filename.push(format!("{this_height}_{timestamp}_{suffix}.parquet"));
-        save_batchrecord_deltas_to_parquet(batch, filename);
-
-        prev_height = this_height;
-        prev_mempool = this_mempool;
-        prev_timestamp = now.timestamp();
-    }
-}
-
-fn save_batchrecord_deltas_to_parquet(batch: RecordBatch, filename: std::path::PathBuf) {
-    // make sure the folder exists
-    std::fs::create_dir_all(filename.parent().unwrap()).unwrap();
-
-    let file = std::fs::File::create(filename).unwrap();
-    let props = WriterProperties::builder()
-        .set_compression(Compression::SNAPPY)
-        .build();
-    let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();
-
-    writer.write(&batch).unwrap();
-    writer.close().unwrap();
-}
-
-fn create_batchrecord_delta_from_pools(
-    prev_mempool: &Mempool,
-    this_mempool: &Mempool,
-) -> RecordBatch {
-    let (keys_removed, keys_added) = delta_of_keys(prev_mempool, this_mempool);
-
-    // TODO: combine into one batch:
-
-    let capacity = keys_removed.len() + keys_added.len();
-
-    let mut txid_values: Vec<String> = Vec::with_capacity(capacity);
-    let mut weight_values: Vec<f64> = Vec::with_capacity(capacity);
-    let mut fee_sat_values: Vec<f64> = Vec::with_capacity(capacity);
-    let mut first_seen_timestamp_values: Vec<u64> = Vec::with_capacity(capacity);
-
-    for txid in keys_removed.iter() {
-        let entry = prev_mempool.get(txid).unwrap();
-        let weight: f64 = entry.weight.unwrap() as f64 * (-1.);
-
-        txid_values.push(txid.to_string());
-        weight_values.push(weight);
-        fee_sat_values.push(entry.fees.base.to_float_in(Denomination::Satoshi));
-        first_seen_timestamp_values.push(entry.time);
-    }
-
-    for txid in keys_added.iter() {
-        let entry = this_mempool.get(txid).unwrap();
-        let weight = entry.weight.unwrap() as f64;
-
-        txid_values.push(txid.to_string());
-        weight_values.push(weight);
-        fee_sat_values.push(entry.fees.base.to_float_in(Denomination::Satoshi));
-        first_seen_timestamp_values.push(entry.time);
-    }
-
-    let txid_array: ArrayRef = Arc::new(StringArray::from(txid_values));
-    let weight_array: ArrayRef = Arc::new(Float64Array::from(weight_values));
-    let fee_sat_array: ArrayRef = Arc::new(Float64Array::from(fee_sat_values));
-    let first_seen_at_array: ArrayRef = Arc::new(UInt64Array::from(first_seen_timestamp_values));
-
-    let schema = Schema::new(vec![
-        Field::new("txid", DataType::Utf8, false),
-        Field::new("weight", DataType::Float64, false),
-        Field::new("fee_sat", DataType::Float64, false),
-        Field::new("first_seen_at", DataType::UInt64, true),
-    ]);
-
-    RecordBatch::try_new(
-        Arc::new(schema),
-        vec![txid_array, weight_array, fee_sat_array, first_seen_at_array],
-    )
-    .unwrap()
-}
-
-fn delta_of_keys(map1: &Mempool, map2: &Mempool) -> (Vec<Txid>, Vec<Txid>) {
-    let mut intersection = HashSet::new();
-    let mut keys_added = Vec::new();
-    let mut keys_removed = Vec::new();
-
-    for key in map1.keys() {
-        if map2.contains_key(key) {
-            intersection.insert(key);
-        } else {
-            keys_removed.push(*key);
+    match &cli.command {
+        Commands::Record => {
+            Record::record().await?;
         }
     }
 
-    for key in map2.keys() {
-        if !intersection.contains(key) {
-            keys_added.push(*key);
-        }
-    }
-
-    (keys_removed, keys_added)
+    Ok(())
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,0 +1,166 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Instant,
+};
+
+use arrow::{
+    array::{ArrayRef, Float64Array, StringArray, UInt64Array},
+    datatypes::{DataType, Field, Schema},
+    record_batch::RecordBatch,
+};
+use bitcoin::{Denomination, Txid};
+use bitcoincore_rest::{responses::GetMempoolEntryResult, Error, Network, RestApi, RestClient};
+use chrono::Timelike;
+use parquet::{arrow::ArrowWriter, basic::Compression, file::properties::WriterProperties};
+use tracing::info;
+
+type Mempool = HashMap<Txid, GetMempoolEntryResult>;
+
+pub struct Record;
+
+impl Record {
+    #[tracing::instrument]
+    pub async fn record() -> Result<(), Error> {
+        let rest_client = RestClient::network_default(Network::Bitcoin);
+
+        let mut prev_height = 0u64;
+        let mut this_height;
+        let mut prev_mempool: Mempool = HashMap::new();
+        let mut this_mempool: Mempool;
+        let mut prev_timestamp = 0i64;
+
+        loop {
+            // execute once per quarter-minute (:00/:15/:30/:45), preventing double execution
+            let now = chrono::Utc::now();
+            if now.second() % 15 != 0 || prev_timestamp == now.timestamp() {
+                tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+                continue;
+            }
+
+            // check height
+            this_height = rest_client.get_chain_info().await?.blocks;
+            let is_new_height = prev_height != this_height;
+            if is_new_height {
+                prev_mempool = HashMap::new();
+                info!("new_height: {:?}", this_height);
+            }
+
+            let start = Instant::now();
+            this_mempool = rest_client.get_mempool().await?;
+            let duration = start.elapsed();
+
+            let batch = Self::create_batchrecord_delta_from_pools(&prev_mempool, &this_mempool);
+
+            info!(
+                "batch_num_rows: {:?}, load_mempool_duration_millis: {:?}",
+                batch.num_rows(),
+                duration.as_millis()
+            );
+
+            let mut filename = std::path::PathBuf::new();
+            let day = now.format("%Y/%m/%d").to_string();
+            let timestamp = now.timestamp();
+            let suffix = if is_new_height { "full" } else { "delta" };
+            filename.push("data");
+            filename.extend(day.split('/'));
+            filename.push(format!("{this_height}_{timestamp}_{suffix}.parquet"));
+            Self::save_batchrecord_deltas_to_parquet(batch, filename);
+
+            prev_height = this_height;
+            prev_mempool = this_mempool;
+            prev_timestamp = now.timestamp();
+        }
+    }
+
+    fn save_batchrecord_deltas_to_parquet(batch: RecordBatch, filename: std::path::PathBuf) {
+        // make sure the folder exists
+        std::fs::create_dir_all(filename.parent().unwrap()).unwrap();
+
+        let file = std::fs::File::create(filename).unwrap();
+        let props = WriterProperties::builder()
+            .set_compression(Compression::SNAPPY)
+            .build();
+        let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();
+
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+    }
+
+    fn create_batchrecord_delta_from_pools(
+        prev_mempool: &Mempool,
+        this_mempool: &Mempool,
+    ) -> RecordBatch {
+        let (keys_removed, keys_added) = Self::delta_of_keys(prev_mempool, this_mempool);
+
+        // TODO: combine into one batch:
+
+        let capacity = keys_removed.len() + keys_added.len();
+
+        let mut txid_values: Vec<String> = Vec::with_capacity(capacity);
+        let mut weight_values: Vec<f64> = Vec::with_capacity(capacity);
+        let mut fee_sat_values: Vec<f64> = Vec::with_capacity(capacity);
+        let mut first_seen_timestamp_values: Vec<u64> = Vec::with_capacity(capacity);
+
+        for txid in keys_removed.iter() {
+            let entry = prev_mempool.get(txid).unwrap();
+            let weight: f64 = entry.weight.unwrap() as f64 * (-1.);
+
+            txid_values.push(txid.to_string());
+            weight_values.push(weight);
+            fee_sat_values.push(entry.fees.base.to_float_in(Denomination::Satoshi));
+            first_seen_timestamp_values.push(entry.time);
+        }
+
+        for txid in keys_added.iter() {
+            let entry = this_mempool.get(txid).unwrap();
+            let weight = entry.weight.unwrap() as f64;
+
+            txid_values.push(txid.to_string());
+            weight_values.push(weight);
+            fee_sat_values.push(entry.fees.base.to_float_in(Denomination::Satoshi));
+            first_seen_timestamp_values.push(entry.time);
+        }
+
+        let txid_array: ArrayRef = Arc::new(StringArray::from(txid_values));
+        let weight_array: ArrayRef = Arc::new(Float64Array::from(weight_values));
+        let fee_sat_array: ArrayRef = Arc::new(Float64Array::from(fee_sat_values));
+        let first_seen_at_array: ArrayRef =
+            Arc::new(UInt64Array::from(first_seen_timestamp_values));
+
+        let schema = Schema::new(vec![
+            Field::new("txid", DataType::Utf8, false),
+            Field::new("weight", DataType::Float64, false),
+            Field::new("fee_sat", DataType::Float64, false),
+            Field::new("first_seen_at", DataType::UInt64, true),
+        ]);
+
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![txid_array, weight_array, fee_sat_array, first_seen_at_array],
+        )
+        .unwrap()
+    }
+
+    fn delta_of_keys(map1: &Mempool, map2: &Mempool) -> (Vec<Txid>, Vec<Txid>) {
+        let mut intersection = HashSet::new();
+        let mut keys_added = Vec::new();
+        let mut keys_removed = Vec::new();
+
+        for key in map1.keys() {
+            if map2.contains_key(key) {
+                intersection.insert(key);
+            } else {
+                keys_removed.push(*key);
+            }
+        }
+
+        for key in map2.keys() {
+            if !intersection.contains(key) {
+                keys_added.push(*key);
+            }
+        }
+
+        (keys_removed, keys_added)
+    }
+}


### PR DESCRIPTION
Basic clap functionality for recording. New commands can be added by extending the `Commands` enum. Moved recording to its own mod, added tracing instead of using `println`.